### PR TITLE
Remove extra semicolon

### DIFF
--- a/src/torrent.c
+++ b/src/torrent.c
@@ -13,7 +13,7 @@
 #include <unistd.h>
 
 #define ERR_EXIT(msg) \
-    do { fputs(msg, stderr); return -1; } while (0);
+    do { fputs(msg, stderr); return -1; } while (0)
 
 // in seconds
 #define TRACKER_POLL_FREQ 300


### PR DESCRIPTION
This extra semicolon is adding nanoseconds onto compile time.